### PR TITLE
chore: improve the way to get current_dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,9 @@ fn main() {
         .get_matches();
     
     //设置软件工作目录，避免下面未使用 PathBuf 的路径使用错误
-    let _ = env::set_current_dir(env::current_exe().unwrap().parent().unwrap());
+    let mut current_exe_dir = env::current_exe().unwrap();
+    let _ = current_exe_dir.pop();
+    let _ = env::set_current_dir(&current_exe_dir);
 
     let dump: bool = matches.is_present("dump");
     let dump_path = matches.value_of("dump").unwrap_or("./dumps/");
@@ -174,7 +176,7 @@ fn main() {
     let mut pick_key_json = pick_key;
     let mut uid_mask_on = true;
     let mut press_y = true;
-    let config_path = env::current_exe().unwrap().parent().unwrap().to_path_buf().join("config.json");
+    let config_path = current_exe_dir.join("config.json").clone();
     if config_path.exists() {
         let config = fs::read_to_string(config_path).unwrap();
         let config: serde_json::Value = serde_json::from_str(&config).unwrap();
@@ -327,7 +329,7 @@ fn main() {
     let pk_config = PickupCofig {
         info,
         hwnd,
-        bw_path: env::current_exe().unwrap().parent().unwrap().to_string_lossy().to_string(),
+        bw_path: current_exe_dir.to_string_lossy().to_string().clone(),
         use_l,
         press_y,
         dump,


### PR DESCRIPTION
避免之前一长串重复取 `env::current()` 然后转格式的代码……（虽然clone也没好到哪里去